### PR TITLE
Add paragraph header

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -141,6 +141,7 @@ Let's take a look at the argument signature for `GridField`:
 
 Let's go back into the CMS and edit our "Regions" page. See that we have a tab now that contains a grid. Give it a try and add some test records.
 
+### Configuring the GridField
 As stated earlier, `GridField` is highly configurable. One of the most common customisations you'll want to make to your grid is the columns that are displayed. In this case, there are only a handful of fields, so only showing `Title` and `Description` isn't so bad, but you can imagine that if the DataObject had 10 distinct fields, we would probably want to tighten that up a bit.
 
 In our case, let's make a minor enhancement, and just add the `Photo` field to our list view. By default, only fields in the `$db` array get included. Since `Photo` is in the `$has_one`, we have to specifically include it.


### PR DESCRIPTION
Added paragraph header to split info in more manageable chunks.
Additional points:
Consider adding download for completed code?
Remember to add link to article when completed from 'Notice that we're skipping over the links. We'll address that in a future lesson.'.
