### PR TITLE
Add .platform.yml file with first compatible infrastructure revision.

### DIFF
--- a/.platform.yml
+++ b/.platform.yml
@@ -1,0 +1,1 @@
+infrastructure: 1.2.0


### PR DESCRIPTION
In version 1.2 of the SilverStripe Platform which is due shortly, we will be introducing a user-driven infrastructure version selection.

This selection will be accomplished by setting the "infrastructure" value in the `.platform.yml` file committed into the root of your site repository. This would usually point to a tag.

This merge request contains an initial `.platform.yml` for your site that sets the revision to "1.2.0" - the first revision compatible with this feature. Note however that the selection in the file will be inactive on a given environment until the Platform Operations team makes the first 1.2.0 deployment.
